### PR TITLE
Avoid uninitialized vid_decoder_ in VideoLoader::impl::read_file()

### DIFF
--- a/src/VideoLoader.cpp
+++ b/src/VideoLoader.cpp
@@ -512,7 +512,9 @@ void VideoLoader::impl::read_file() {
         vid_decoder_->decode_packet(nullptr);
     }
 
-    vid_decoder_->decode_packet(nullptr); // stop decoding
+    if (vid_decoder_) {
+        vid_decoder_->decode_packet(nullptr); // stop decoding
+    }
     log_.info() << "Leaving read_file" << std::endl;
 }
 


### PR DESCRIPTION
This simple program crashes.

```
#include "VideoLoader.h"

int main() {
    NVVL::VideoLoader(0);
}
```

This is because:
 + `VideoLoader::~VideoLoader()` is called
 + `VideoLoader::pimpl::finish()` is called and `done_` is set to `true`.
 + `VideoLoader::impl::read_file()` breaks from its `while` loop
 + `vid_decoder_` is uninitialized because nothing has pushed to `send_queue`

This PR fixes the bug by simply check if `vid_decoder_` is NULL.
