### PR TITLE
Add a missing backslash in a Dockerfile

### DIFF
--- a/docker/Dockerfile.interactive_opencv
+++ b/docker/Dockerfile.interactive_opencv
@@ -54,7 +54,7 @@ RUN apt-get install -y pkg-config doxygen wget && \
     apt-get autoremove -y
 
 # paired down OpenCV build, just enough for examples
-RUN apt-get install -y wget &&
+RUN apt-get install -y wget && \
     cd /tmp && \
     wget https://github.com/opencv/opencv/archive/$OPENCV_VERSION.tar.gz && \
     tar xf $OPENCV_VERSION.tar.gz && \


### PR DESCRIPTION
This PR fixes `Dockerfile.interactive_opencv` which we can't build due to a missing backslash.