### PR TITLE
Added get_label function to pytorch bindings (nvvl.VideoDataset)

### DIFF
--- a/examples/pytorch_superres/main.py
+++ b/examples/pytorch_superres/main.py
@@ -130,7 +130,7 @@ def main(args):
         iter_start = time.perf_counter()
 
         # TRAINING EPOCH LOOP
-        for i, (inputs, labels) in enumerate(train_loader):
+        for i, inputs in enumerate(train_loader):
 
             if args.loader == 'NVVL':
                 inputs = inputs['input']

--- a/examples/pytorch_superres/main.py
+++ b/examples/pytorch_superres/main.py
@@ -130,7 +130,7 @@ def main(args):
         iter_start = time.perf_counter()
 
         # TRAINING EPOCH LOOP
-        for i, inputs in enumerate(train_loader):
+        for i, (inputs, labels) in enumerate(train_loader):
 
             if args.loader == 'NVVL':
                 inputs = inputs['input']

--- a/pytorch/nvvl/loader.py
+++ b/pytorch/nvvl/loader.py
@@ -78,10 +78,12 @@ class VideoLoader(object):
     def _receive_batch(self):
         batch_size = self.batch_size_queue.popleft()
         t = self.dataset._create_tensor_map(batch_size)
+        labels = []
         for i in range(batch_size):
-            self.dataset._start_receive(t, i)
+            _, label = self.dataset._start_receive(t, i)
+            labels.append(label)
 
-        self.tensor_queue.append((batch_size, t))
+        self.tensor_queue.append((batch_size, t, labels))
 
     def get_stats(self):
         return self.dataset.get_stats()
@@ -101,11 +103,11 @@ class VideoLoader(object):
         if self.batch_size_queue:
             self._receive_batch()
 
-        batch_size, t = self.tensor_queue.popleft()
+        batch_size, t, labels = self.tensor_queue.popleft()
         for i in range(batch_size):
             self.dataset._finish_receive()
 
-        return t
+        return t, labels
 
     def __iter__(self):
         if self.dataset.samples_left != 0:

--- a/pytorch/nvvl/loader.py
+++ b/pytorch/nvvl/loader.py
@@ -107,7 +107,10 @@ class VideoLoader(object):
         for i in range(batch_size):
             self.dataset._finish_receive()
 
-        return t, labels
+        if any(label is not None for label in labels):
+            t["labels"] = labels
+
+        return t
 
     def __iter__(self):
         if self.dataset.samples_left != 0:

--- a/pytorch/test/benchmark.py
+++ b/pytorch/test/benchmark.py
@@ -45,7 +45,7 @@ def main(args):
 
         start = time.time()
 
-        for i,x in enumerate(loader, 1):
+        for i,(x, y) in enumerate(loader, 1):
 
             if args.loader != 'NVVL':
                 x = x.cuda()

--- a/pytorch/test/benchmark.py
+++ b/pytorch/test/benchmark.py
@@ -45,7 +45,7 @@ def main(args):
 
         start = time.time()
 
-        for i,(x, y) in enumerate(loader, 1):
+        for i, x in enumerate(loader, 1):
 
             if args.loader != 'NVVL':
                 x = x.cuda()


### PR DESCRIPTION
Added an optional parameter to the pytorch nvvl.VideoDataset that is a callable which obtains the labels for a filename/frame.

I changed the return for `__next__` on VideoLoader to include the labels. I also updated every reference I could find to VideoLoader.__next__ in the other code (it's entirely possible I missed one; I couldn't test the other code because I don't have access to the base docker image in `//pytorch/test/docker/Dockerfile`.

I believe that labels are ubiquitous to use cases, so I think that it is acceptable that it is always returned. 

I couldn't find any uses of VideoDataset.__getitem__ in the code base.

Please advise for any changes/tests you want.