### PR TITLE
Made pytorch VideoLoader's buffer_length an __init__ parameter.

### DIFF
--- a/pytorch/nvvl/loader.py
+++ b/pytorch/nvvl/loader.py
@@ -37,10 +37,13 @@ class VideoLoader(object):
         drop the last incomplete batch. It is currently not
         implemented to have this set to False. (Default: True)
 
+    buffer_length : int, optional
+        number of batches to preload (Default: 3)
+
     """
     def __init__(self, dataset, batch_size=1, shuffle=False,
                  distributed=False, sampler=None,
-                 batch_sampler=None, drop_last=True):
+                 batch_sampler=None, drop_last=True, buffer_length=3):
         self.dataset = dataset
         self.batch_size = batch_size
         self.drop_last = drop_last
@@ -73,7 +76,7 @@ class VideoLoader(object):
 
         self.tensor_queue = collections.deque()
         self.batch_size_queue = collections.deque()
-        self.buffer_length = 3
+        self.buffer_length = buffer_length
 
     def _receive_batch(self):
         batch_size = self.batch_size_queue.popleft()


### PR DESCRIPTION
I had a problem that the default value was using up too much memory (4K frames are big, you know). I figure this should be an init parameter.

P.S. Sorry that there's a bunch of pull requests from me. There's just stuff I need NVVL to do. Hope that's cool (i.e. let me know if I should just stop)