### PR TITLE
Fix invalid crop position for flipped frames

### DIFF
--- a/src/detail/cuda/imgproc.cu
+++ b/src/detail/cuda/imgproc.cu
@@ -83,7 +83,7 @@ __global__ void process_frame_kernel(
 
     auto src_x = 0.0f;
     if (dst.desc.horiz_flip) {
-        src_x = (dst.desc.width - dst.desc.crop_x - dst_x) * fx;
+        src_x = (dst.desc.scale_width - dst.desc.crop_x - dst_x) * fx;
     } else {
         src_x = (dst.desc.crop_x + dst_x) * fx;
     }


### PR DESCRIPTION
There's a typo/bug when calculating horizontal cropping position.

Example (only X coordinate is mentioned for simplicity): 
 - input frame is 1000px
 - flip frame
 - scale to 500px (fx=2)
 - crop [50:350]

Assuming `dst_x == 280`, `src_x` should be (500 - 50 - 280) * 2 = 340 
With current implementation result is (300 - 50 - 280) * 2 = **-60**
As a result, wrong memory is accessed and image is not generated properly.