### PR TITLE
Make stream non-blocking

### DIFF
--- a/src/detail/Decoder.cpp
+++ b/src/detail/Decoder.cpp
@@ -18,7 +18,7 @@ CUStream::CUStream(int device_id, bool default_stream) : created_{false}, stream
             set_device = true;
             cudaSetDevice(device_id);
         }
-        cucall(cudaStreamCreate(&stream_));
+        cucall(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
         created_ = true;
         if (set_device) {
             cucall(cudaSetDevice(orig_device));


### PR DESCRIPTION
The stream used for decoding is currently not created as non-blocking. This is fine if the client code doesn't run on the default stream, but since e.g. PyTorch uses the default stream for almost everything, that results in the default stream causing implicit synchronization so the work is effectively serialized. This PR changes that because the stream being created using the cudaStreamCreateWithFlags API with the cudaStreamNonBlocking flag, rather than via the cudaStreamCreate API.