### PR TITLE
Rescale PTS value to nvdecoder time base before submitting to NvDecod…

### DIFF
--- a/src/VideoLoader.cpp
+++ b/src/VideoLoader.cpp
@@ -244,8 +244,7 @@ VideoLoader::impl::OpenFile& VideoLoader::impl::get_or_open_file(std::string fil
 
             vid_decoder_ = std::unique_ptr<detail::Decoder>{
                 new detail::NvDecoder(device_id_, log_,
-                                      codecpar(stream),
-                                      stream->time_base)};
+                                      codecpar(stream))};
         } else { // already opened a file
             if (!vid_decoder_) {
                 throw std::logic_error("width is already set but we don't have a vid_decoder_");
@@ -451,6 +450,9 @@ void VideoLoader::impl::read_file() {
 
             stats_.bytes_decoded += pkt->size;
             stats_.packets_decoded++;
+
+            AVRational nv_time_base_ = {1, 10000000};
+            pkt->pts = av_rescale_q(pkt->pts, file.stream_base_, nv_time_base_);
 
             if (file.bsf_ctx_ && pkt->size > 0) {
                 int ret;

--- a/src/detail/NvDecoder.cpp
+++ b/src/detail/NvDecoder.cpp
@@ -30,11 +30,9 @@ NvDecoder::NvDecoder() {
 
 NvDecoder::NvDecoder(int device_id,
                      Logger& logger,
-                     const CodecParameters* codecpar,
-                     AVRational time_base)
+                     const CodecParameters* codecpar)
     : Decoder{device_id, logger, codecpar},
       device_{}, context_{}, parser_{}, decoder_{logger},
-      time_base_{time_base.num, time_base.den},
       frame_in_use_(32), // 32 is cuvid's max number of decode surfaces
       recv_queue_{}, frame_queue_{}, output_queue_{},
       current_recv_{}, textures_{}, done_{false}
@@ -142,11 +140,7 @@ int NvDecoder::decode_av_packet(AVPacket* avpkt) {
         cupkt.payload = avpkt->data;
         if (avpkt->pts != AV_NOPTS_VALUE) {
             cupkt.flags = CUVID_PKT_TIMESTAMP;
-            if (time_base_.num && time_base_.den) {
-                cupkt.timestamp = av_rescale_q(avpkt->pts, time_base_, nv_time_base_);
-            } else {
-                cupkt.timestamp = avpkt->pts;
-            }
+            cupkt.timestamp = avpkt->pts;
         }
     } else {
         cupkt.flags = CUVID_PKT_ENDOFSTREAM;

--- a/src/detail/NvDecoder.h
+++ b/src/detail/NvDecoder.h
@@ -29,8 +29,7 @@ class NvDecoder : public Decoder
     NvDecoder();
 
     NvDecoder(int device_id, Logger& logger,
-              const CodecParameters* codecpar,
-              AVRational time_base);
+              const CodecParameters* codecpar);
 
     bool initialized() const;
 
@@ -99,7 +98,6 @@ class NvDecoder : public Decoder
     CUVideoParser parser_;
     CUVideoDecoder decoder_;
 
-    AVRational time_base_;
     AVRational nv_time_base_ = {1, 10000000};
     AVRational frame_base_;
 


### PR DESCRIPTION
…er as stream timebase might be different for clips. 
Different streams have different time base, currently NvDecoder is initialized with the time base of first stream which is decoded. If the subsequent stream's time base doesnt match , frame number generated from PTS  by nvdecoder will be wrong.